### PR TITLE
Message System #140

### DIFF
--- a/resdex-v2/src/components/chat/Avatar.tsx
+++ b/resdex-v2/src/components/chat/Avatar.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+export default function Avatar({
+  src,
+  alt,
+  size = 24,
+}: { src?: string | null; alt: string; size?: number }) {
+  const style = { width: size, height: size };
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt={alt}
+        style={style}
+        className="rounded-full object-cover ring-2 ring-white"
+      />
+    );
+  }
+  // Fallback initials
+  const initials =
+    alt
+      .split(" ")
+      .filter(Boolean)
+      .slice(0, 2)
+      .map(s => s[0]?.toUpperCase())
+      .join("") || "?";
+  return (
+    <div
+      style={style}
+      className="rounded-full bg-gray-300 text-gray-700 grid place-items-center text-[10px] font-semibold ring-2 ring-white"
+      aria-label={alt}
+    >
+      {initials}
+    </div>
+  );
+}

--- a/resdex-v2/src/components/chat/ChatBubble.tsx
+++ b/resdex-v2/src/components/chat/ChatBubble.tsx
@@ -1,0 +1,55 @@
+"use client";
+import React from "react";
+import Avatar from "./Avatar";
+import type { WithRunFlags } from "@/lib/chat/runs";
+
+export default function ChatBubble({ msg, showMineAvatar = false }: {
+  msg: WithRunFlags;
+  /** set true if you also want your own avatar on your run end */
+  showMineAvatar?: boolean;
+}) {
+  const isMine = msg.isMine;
+
+  const wrap = isMine ? "justify-end" : "justify-start";
+  const bubble = isMine
+    ? "bg-[#2a2a2a] text-white"
+    : "bg-gray-200 text-black";
+
+  // Slightly different rounding so grouped runs look connected
+  const radius = isMine
+    ? [
+        "rounded-2xl",
+        msg.isRunStart ? "rounded-tr-md" : "rounded-tr-sm",
+        msg.isRunEnd   ? "rounded-br-2xl" : "rounded-br-md",
+        "rounded-tl-2xl",
+      ].join(" ")
+    : [
+        "rounded-2xl",
+        msg.isRunStart ? "rounded-tl-md" : "rounded-tl-sm",
+        msg.isRunEnd   ? "rounded-bl-2xl" : "rounded-bl-md",
+        "rounded-tr-2xl",
+      ].join(" ");
+
+  const shouldShowAvatar = msg.isRunEnd && (!isMine || showMineAvatar);
+
+  return (
+    <div className={`relative flex ${wrap}`}>
+      {/* bubble */}
+      <div className={`relative max-w-[75%] px-3 py-2 ${bubble} ${radius} ${!isMine ? 'ml-6' : ''}`}>
+        <p className="whitespace-pre-wrap leading-relaxed">{msg.text}</p>
+
+        {/* Avatar appears only on the LAST message of a run */}
+        {shouldShowAvatar && (
+          <div
+            className={`absolute top-1/2 -translate-y-1/2 ${
+              isMine ? "-right-8" : "-left-8"
+            }`}
+            aria-hidden
+          >
+            <Avatar src={msg.user.avatarUrl} alt={msg.user.name} size={30} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/resdex-v2/src/components/chat/ChatThread.tsx
+++ b/resdex-v2/src/components/chat/ChatThread.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React from "react";
+import ChatBubble from "./ChatBubble";
+import { annotateRuns, type ChatMessage } from "@/lib/chat/runs";
+
+export default function ChatThread({
+  messages,
+  currentUserId,
+}: {
+  messages: ChatMessage[];
+  currentUserId: string;
+}) {
+  const rows = annotateRuns(messages, currentUserId);
+  return (
+    <div className="space-y-1">
+      {rows.map(m => (
+        <ChatBubble key={m.id} msg={m} />
+      ))}
+    </div>
+  );
+}

--- a/resdex-v2/src/lib/chat/runs.ts
+++ b/resdex-v2/src/lib/chat/runs.ts
@@ -1,0 +1,38 @@
+export type ChatUser = { id: string; name: string; avatarUrl?: string | null };
+export type ChatMessage = {
+  id: string;
+  userId: string;
+  text: string;
+  createdAt: string; // ISO
+  user: ChatUser;
+};
+
+export type WithRunFlags = ChatMessage & {
+  isMine: boolean;
+  isRunStart: boolean;
+  isRunEnd: boolean;
+};
+
+/**
+ * Annotate messages with run boundaries based ONLY on consecutive same-sender.
+ * No time gap logic. A "run" ends when the NEXT message is from a different sender.
+ */
+export function annotateRuns(
+  messages: ChatMessage[],
+  currentUserId: string
+): WithRunFlags[] {
+  return messages.map((m, i, arr) => {
+    const prev = arr[i - 1];
+    const next = arr[i + 1];
+
+    const prevSame = !!prev && prev.userId === m.userId;
+    const nextSame = !!next && next.userId === m.userId;
+
+    return {
+      ...m,
+      isMine: m.userId === currentUserId,
+      isRunStart: !prevSame,
+      isRunEnd: !nextSame,
+    };
+  });
+}

--- a/resdex/src/pages/Messages.js
+++ b/resdex/src/pages/Messages.js
@@ -207,23 +207,23 @@ const ChatWindow = ({ recipient, currentUser, chatId, onBack }) => {
                 {messages.map((msg, index) => {
                     const isCurrentUser = msg.senderId === currentUser.uid;
                     return (
-                        <div key={index} className={`mb-3 d-flex ${isCurrentUser ? 'justify-content-end' : 'justify-content-start'}`}>
+                        <div key={index} className={`mb-1 d-flex ${isCurrentUser ? 'justify-content-end' : 'justify-content-start'}`}>
                             <div 
                                 className="inline-block text-sm custom-read text-white"
                                 style={{
                                     backgroundColor: isCurrentUser ? '#5b5b5b' : '#2a2a2a',
                                     maxWidth: 'fit-content',
-                                    paddingLeft: '30px',
-                                    paddingRight: '30px',
-                                    paddingTop: '10px',
-                                    paddingBottom: '10px',
+                                    paddingLeft: '20px',
+                                    paddingRight: '20px',
+                                    paddingTop: '8px',
+                                    paddingBottom: '8px',
                                     borderRadius: '20px',
                                 }}
                             >
                                 <p className="break-words m-0">{msg.text}</p>
                                 
                             </div>
-                            <p className={`text-xs mt-1 text-muted opacity-70 pt-2 m-0 text-${isCurrentUser ? 'right' : 'left'}`} style={{ fontSize: "10px", paddingLeft: '10px' }}>
+                            <p className={`text-xs mt-1 text-muted opacity-70 pt-1 m-0 text-${isCurrentUser ? 'right' : 'left'}`} style={{ fontSize: "10px", paddingLeft: '8px' }}>
                                     {new Date(msg.timestamp).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}
                                 </p>
                         </div>


### PR DESCRIPTION
Chat UI enhancement 
* Fixes Issue #140 


feat(chat): Instagram-style grouped bubbles with last-message avatars

- Add annotateRuns() to compute run boundaries (start/end) with consecutive same-sender logic
- New ChatBubble/ChatThread components with Tailwind styling and run-based avatar display
- Avatar component with initials fallback and ring styling
- Show avatar only on the last message of a sender's consecutive run
- Support for group chats with per-sender avatar logic
- Toggle option for showing own message avatars
- Maintains existing chat functionality while improving visual hierarchy